### PR TITLE
Add firmware version sensor and clean up diagnostic logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ epcal/
 │   ├── coordinator.py          # Data coordinator (calendar/weather)
 │   ├── camera.py               # Preview camera entity
 │   ├── image.py                # Bitmap image entities
-│   ├── sensor.py               # Last update sensor
+│   ├── sensor.py               # Sensor entities (last update, last check-in, firmware version)
 │   ├── http_views.py           # Announce API + bitmap serving
 │   ├── services.py             # trigger_render + upload_firmware services
 │   ├── firmware_manager.py     # Firmware binary storage for OTA

--- a/custom_components/eink_calendar/const.py
+++ b/custom_components/eink_calendar/const.py
@@ -13,6 +13,7 @@ DEFAULT_REFRESH_INTERVAL = 15  # minutes
 CAMERA_NAME = "preview"
 SENSOR_LAST_UPDATE_NAME = "last_update"
 SENSOR_LAST_CHECKIN_NAME = "last_checkin"
+SENSOR_FIRMWARE_VERSION_NAME = "firmware_version"
 IMAGE_BLACK_TOP_NAME = "black_layer_top"
 IMAGE_BLACK_BOTTOM_NAME = "black_layer_bottom"
 IMAGE_RED_TOP_NAME = "red_layer_top"

--- a/custom_components/eink_calendar/coordinator.py
+++ b/custom_components/eink_calendar/coordinator.py
@@ -37,12 +37,15 @@ class EinkCalendarDataCoordinator(DataUpdateCoordinator):
         self.entry = entry
         self._last_render_day: datetime | None = None
         self.last_checkin: datetime | None = None
+        self.firmware_version: str = "unknown"
         self._cached_render = None
         self._cached_render_timestamp: datetime | None = None
 
-    def record_checkin(self) -> None:
+    def record_checkin(self, firmware_version: str | None = None) -> None:
         """Record a device check-in and notify listeners (sensors)."""
         self.last_checkin = dt_util.now()
+        if firmware_version is not None:
+            self.firmware_version = firmware_version
         self.async_set_updated_data(self.data)
 
     def invalidate_render_cache(self) -> None:

--- a/custom_components/eink_calendar/http_views.py
+++ b/custom_components/eink_calendar/http_views.py
@@ -50,12 +50,12 @@ class EinkCalendarAnnounceView(HomeAssistantView):
             # Check if MAC matches an existing config entry
             for entry in self.hass.config_entries.async_entries(DOMAIN):
                 if entry.data.get(CONF_MAC_ADDRESS) == mac:
-                    # Record check-in
+                    # Record check-in and firmware version
                     coordinator = self.hass.data.get(DOMAIN, {}).get(entry.entry_id)
                     if coordinator:
-                        coordinator.record_checkin()
+                        coordinator.record_checkin(firmware_version=firmware_version)
 
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Announce: MAC=%s configured, entry_id=%s",
                         mac,
                         entry.entry_id,
@@ -149,7 +149,7 @@ class EinkCalendarBitmapView(HomeAssistantView):
     ) -> web.Response:
         """Serve bitmap layer."""
         try:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Bitmap request: entry_id=%s, layer=%s", entry_id, layer,
             )
 
@@ -214,7 +214,7 @@ class EinkCalendarBitmapView(HomeAssistantView):
                 fw_version = request.headers.get("X-Firmware-Version", "")
                 image_changed = not (if_none_match and if_none_match == etag)
 
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Check request: If-None-Match=%s, ETag=%s, FW=%s, image_changed=%s",
                     if_none_match, etag, fw_version, image_changed,
                 )

--- a/custom_components/eink_calendar/sensor.py
+++ b/custom_components/eink_calendar/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import CONF_DEVICE_NAME, CONF_MAC_ADDRESS, DOMAIN, SENSOR_LAST_CHECKIN_NAME, SENSOR_LAST_UPDATE_NAME
+from .const import CONF_DEVICE_NAME, CONF_MAC_ADDRESS, DOMAIN, SENSOR_FIRMWARE_VERSION_NAME, SENSOR_LAST_CHECKIN_NAME, SENSOR_LAST_UPDATE_NAME
 from .coordinator import EinkCalendarDataCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,6 +28,7 @@ async def async_setup_entry(
         [
             EinkCalendarLastUpdateSensor(coordinator, entry),
             EinkCalendarLastCheckinSensor(coordinator, entry),
+            EinkCalendarFirmwareVersionSensor(coordinator, entry),
         ]
     )
 
@@ -87,3 +88,35 @@ class EinkCalendarLastCheckinSensor(SensorEntity):
     def native_value(self) -> datetime | None:
         """Return the last check-in timestamp."""
         return self.coordinator.last_checkin
+
+
+class EinkCalendarFirmwareVersionSensor(SensorEntity):
+    """Sensor showing the ESP32's firmware version."""
+
+    _attr_icon = "mdi:chip"
+
+    def __init__(self, coordinator: EinkCalendarDataCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        self.coordinator = coordinator
+        self.entry = entry
+        self._attr_name = f"{entry.data.get(CONF_DEVICE_NAME, 'E-Ink Calendar')} Firmware Version"
+        self._attr_unique_id = f"{entry.entry_id}_{SENSOR_FIRMWARE_VERSION_NAME}"
+        mac = entry.data.get(CONF_MAC_ADDRESS)
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, mac)} if mac else {(DOMAIN, entry.entry_id)},
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Register listener when entity is added."""
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> str:
+        """Return the firmware version string."""
+        return self.coordinator.firmware_version

--- a/custom_components/eink_calendar/tests/conftest.py
+++ b/custom_components/eink_calendar/tests/conftest.py
@@ -25,8 +25,10 @@ _HA_MODULES = [
     "homeassistant.core",
     "homeassistant.helpers",
     "homeassistant.helpers.device_registry",
+    "homeassistant.helpers.entity_platform",
     "homeassistant.helpers.entity_registry",
     "homeassistant.helpers.update_coordinator",
+    "homeassistant.components.sensor",
     "homeassistant.util",
     "homeassistant.util.dt",
     "aiohttp",
@@ -35,3 +37,74 @@ _HA_MODULES = [
 ]
 for mod in _HA_MODULES:
     sys.modules.setdefault(mod, MagicMock())
+
+
+# Provide real base classes so our code can inherit properly.
+# HA's _attr_* pattern: setting _attr_foo makes self.foo return that value.
+class _FakeEntity:
+    """Minimal Entity base that supports HA's _attr_* property pattern."""
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+    @property
+    def name(self):
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def unique_id(self):
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def icon(self):
+        return getattr(self, "_attr_icon", None)
+
+    @property
+    def device_class(self):
+        return getattr(self, "_attr_device_class", None)
+
+    @property
+    def device_info(self):
+        return getattr(self, "_attr_device_info", None)
+
+
+class _FakeSensorEntity(_FakeEntity):
+    """Minimal SensorEntity stand-in."""
+
+    @property
+    def native_value(self):
+        return getattr(self, "_attr_native_value", None)
+
+
+class _FakeDataUpdateCoordinator:
+    """Minimal DataUpdateCoordinator stand-in."""
+
+    def __init__(self, hass, logger, *, name, update_interval):
+        self.hass = hass
+        self.logger = logger
+        self.name = name
+        self.update_interval = update_interval
+        self.data = None
+        self.last_update_success = True
+        self._listeners = []
+
+    def async_set_updated_data(self, data):
+        self.data = data
+        for callback in self._listeners:
+            callback()
+
+    def async_add_listener(self, callback):
+        self._listeners.append(callback)
+        return lambda: self._listeners.remove(callback)
+
+    async def async_request_refresh(self):
+        pass
+
+
+# Patch the real base classes into the mocked modules
+sys.modules["homeassistant.components.sensor"].SensorEntity = _FakeSensorEntity
+sys.modules["homeassistant.components.sensor"].SensorDeviceClass = MagicMock()
+sys.modules["homeassistant.helpers.update_coordinator"].DataUpdateCoordinator = (
+    _FakeDataUpdateCoordinator
+)
+sys.modules["homeassistant.helpers.update_coordinator"].UpdateFailed = Exception

--- a/custom_components/eink_calendar/tests/test_firmware_sensor.py
+++ b/custom_components/eink_calendar/tests/test_firmware_sensor.py
@@ -1,0 +1,124 @@
+"""Tests for firmware version tracking and sensor."""
+
+from unittest.mock import MagicMock
+
+from custom_components.eink_calendar.const import (
+    CONF_DEVICE_NAME,
+    CONF_MAC_ADDRESS,
+    DOMAIN,
+    SENSOR_FIRMWARE_VERSION_NAME,
+)
+from custom_components.eink_calendar.coordinator import EinkCalendarDataCoordinator
+from custom_components.eink_calendar.sensor import EinkCalendarFirmwareVersionSensor
+
+
+def make_hass():
+    hass = MagicMock()
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+def make_entry(entry_id="test-entry-1", mac="AA:BB:CC:DD:EE:FF", name="Kitchen Calendar"):
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.data = {CONF_MAC_ADDRESS: mac, CONF_DEVICE_NAME: name}
+    entry.options = {}
+    return entry
+
+
+def make_coordinator(hass=None, entry=None):
+    hass = hass or make_hass()
+    entry = entry or make_entry()
+    return EinkCalendarDataCoordinator(hass, entry)
+
+
+class TestCoordinatorFirmwareTracking:
+    def test_firmware_version_defaults_to_unknown(self):
+        """Coordinator should report 'unknown' before any device check-in."""
+        coord = make_coordinator()
+        assert coord.firmware_version == "unknown"
+
+    def test_record_checkin_with_firmware_version(self):
+        """record_checkin should store firmware version when provided."""
+        coord = make_coordinator()
+        coord.record_checkin(firmware_version="1.1.0")
+        assert coord.firmware_version == "1.1.0"
+
+    def test_record_checkin_without_firmware_version(self):
+        """record_checkin without firmware_version should not change it."""
+        coord = make_coordinator()
+        coord.record_checkin(firmware_version="1.0.0")
+        coord.record_checkin()  # No firmware version
+        assert coord.firmware_version == "1.0.0"
+
+    def test_firmware_version_updates(self):
+        """Firmware version should update on subsequent check-ins."""
+        coord = make_coordinator()
+        coord.record_checkin(firmware_version="1.0.0")
+        assert coord.firmware_version == "1.0.0"
+        coord.record_checkin(firmware_version="1.1.0")
+        assert coord.firmware_version == "1.1.0"
+
+    def test_record_checkin_notifies_listeners(self):
+        """Check-in with firmware version should notify listeners once."""
+        coord = make_coordinator()
+        callback = MagicMock()
+        coord.async_add_listener(callback)
+        coord.record_checkin(firmware_version="1.1.0")
+        callback.assert_called_once()
+
+
+class TestFirmwareVersionSensor:
+    def test_sensor_name(self):
+        """Sensor name should include device name."""
+        entry = make_entry(name="Kitchen Calendar")
+        coord = make_coordinator(entry=entry)
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        assert "Kitchen Calendar" in sensor.name
+        assert "Firmware" in sensor.name
+
+    def test_sensor_unique_id(self):
+        """Sensor unique_id should use entry_id and sensor name constant."""
+        entry = make_entry(entry_id="abc123")
+        coord = make_coordinator(entry=entry)
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        assert sensor.unique_id == f"abc123_{SENSOR_FIRMWARE_VERSION_NAME}"
+
+    def test_sensor_icon(self):
+        """Sensor should use chip icon."""
+        coord = make_coordinator()
+        entry = make_entry()
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        assert sensor.icon == "mdi:chip"
+
+    def test_sensor_value_default(self):
+        """Sensor should return 'unknown' when no firmware version recorded."""
+        coord = make_coordinator()
+        entry = make_entry()
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        assert sensor.native_value == "unknown"
+
+    def test_sensor_value_after_checkin(self):
+        """Sensor should return firmware version after device reports it."""
+        coord = make_coordinator()
+        entry = make_entry()
+        coord.record_checkin(firmware_version="1.1.0")
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        assert sensor.native_value == "1.1.0"
+
+    def test_sensor_device_info_uses_mac(self):
+        """Sensor device_info should use MAC as identifier."""
+        entry = make_entry(mac="AA:BB:CC:DD:EE:FF")
+        coord = make_coordinator(entry=entry)
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "AA:BB:CC:DD:EE:FF") in identifiers
+
+    def test_sensor_device_info_fallback_to_entry_id(self):
+        """Sensor should fall back to entry_id if no MAC."""
+        entry = make_entry(mac="", entry_id="fallback-id")
+        entry.data = {CONF_MAC_ADDRESS: "", CONF_DEVICE_NAME: "Test"}
+        coord = make_coordinator(entry=entry)
+        sensor = EinkCalendarFirmwareVersionSensor(coord, entry)
+        identifiers = sensor.device_info["identifiers"]
+        assert (DOMAIN, "fallback-id") in identifiers

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,6 +33,7 @@ Pass any pytest arguments through the script:
 | `test_event_renderer.py` | `format_multi_day_time` (arrows), `sort_events_by_priority` (all-day first) |
 | `test_weather_utils.py` | `get_forecast_for_date` (matching, missing data, timezone handling) |
 | `test_renderer_integration.py` | Full `render_calendar` + `render_to_png` pipeline, legend creation |
+| `test_firmware_sensor.py` | Firmware version sensor entity (value from coordinator, listener registration) |
 | `test_visual_regression.py` | Renders various scenarios to PNG for visual inspection |
 
 ### Visual Regression


### PR DESCRIPTION
## Summary

- Add `EinkCalendarFirmwareVersionSensor` showing the ESP32's reported firmware version (e.g., "1.1.0")
- Coordinator tracks firmware version via `record_checkin(firmware_version=...)` — single notification per check-in
- Downgrade 3 diagnostic `_LOGGER.warning` calls to `_LOGGER.debug` in http_views.py (announce, bitmap request, check request)
- Improve test infrastructure: fake HA base classes (`SensorEntity`, `DataUpdateCoordinator`) in conftest.py

## Test plan

- [x] 12 new tests for firmware version sensor and coordinator tracking
- [x] All 89 non-pre-existing tests pass (5 test_services failures are pre-existing on main)
- [ ] Verify sensor appears in HA after device announces
- [ ] Verify firmware version updates after OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)